### PR TITLE
Traced Data: Dict Signature

### DIFF
--- a/core_data_modules/traced_data.py
+++ b/core_data_modules/traced_data.py
@@ -27,11 +27,11 @@ class Metadata(object):
 
 
 class TracedData(object):
-    def __init__(self, data, user, program, timestamp, prev=None):
+    def __init__(self, data, metadata, prev=None):
         self.__prev = prev
         self.__data = data
         self.__sha = self.__sha_with_prev(data, "" if prev is None else prev.__sha)
-        self.__metadata = Metadata(user, program, timestamp)
+        self.__metadata = metadata
 
     @staticmethod
     def __sha_with_prev(data, prev_sha):
@@ -54,12 +54,11 @@ class TracedData(object):
     def __getitem__(self, key):
         return self.get(key)
 
-    def append(self, new_data, user, program, timestamp):
-        self.__prev = TracedData(
-            self.__data, self.__metadata.user, self.__metadata.program, self.__metadata.timestamp, self.__prev)
+    def append(self, new_data, new_metadata):
+        self.__prev = TracedData(self.__data, self.__metadata, self.__prev)
         self.__data = new_data
         self.__sha = self.__sha_with_prev(self.__data, self.__prev.__sha)
-        self.__metadata = Metadata(user, program, timestamp)
+        self.__metadata = new_metadata
 
     @deprecated
     def has_key(self, key):

--- a/core_data_modules/traced_data.py
+++ b/core_data_modules/traced_data.py
@@ -1,0 +1,139 @@
+import hashlib
+import json
+from deprecation import deprecated
+
+import six
+
+
+class SHAUtils(object):
+    @staticmethod
+    def sha_string(string):
+        return hashlib.sha256(string.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def stringify_dict(cls, d):
+        return json.dumps(d, sort_keys=True)
+
+    @classmethod
+    def sha_dict(cls, d):
+        return cls.sha_string(cls.stringify_dict(d))
+
+
+class Metadata(object):
+    def __init__(self, user, program, timestamp):
+        self.user = user
+        self.program = program
+        self.timestamp = timestamp
+
+
+class TracedData(object):
+    def __init__(self, data, user, program, timestamp, prev=None):
+        self.__prev = prev
+        self.__data = data
+        self.__sha = self.__sha_with_prev(data, "" if prev is None else prev.__sha)
+        self.__metadata = Metadata(user, program, timestamp)
+
+    @staticmethod
+    def __sha_with_prev(data, prev_sha):
+        return SHAUtils.sha_dict({"data": data, "prev_sha": prev_sha})
+
+    def __len__(self):
+        if self.__prev is None:
+            return len(self.__data)
+        else:
+            return len(self.__data) + len(self.__prev)
+
+    def get(self, key, default=None):
+        if key in self.__data:
+            return self.__data[key]
+        elif self.__prev is not None:
+            return self.__prev.get(key, default)
+        else:
+            return default
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def append(self, new_data, user, program, timestamp):
+        self.__prev = TracedData(
+            self.__data, self.__metadata.user, self.__metadata.program, self.__metadata.timestamp, self.__prev)
+        self.__data = new_data
+        self.__sha = self.__sha_with_prev(self.__data, self.__prev.__sha)
+        self.__metadata = Metadata(user, program, timestamp)
+
+    @deprecated
+    def has_key(self, key):
+        if self.__data.has_key(key):
+            return True
+        elif self.__prev is not None:
+            return self.__prev.has_key(key)
+        else:
+            return False
+
+    def __contains__(self, key):
+        if key in self.__data:
+            return True
+        elif self.__prev is not None:
+            return key in self.__prev
+        else:
+            return False
+
+    def items(self):
+        if self.__prev is None:
+            return self.__data.items()
+        else:
+            # TODO: In Python 3 self.__prev.items() returns an iterator, which is immediately expanded to build a dict.
+            # TODO: Consider a rewrite which does not require performing this expansion.
+            prev_items = dict(self.__prev.items())
+            for (key, value) in six.iteritems(self.__data):
+                prev_items[key] = value
+            return prev_items.items()
+
+    def keys(self):
+        if self.__prev is None:
+            return self.__data.keys()
+        else:
+            prev_items = dict(self.__prev.items())
+            for (key, value) in six.iteritems(self.__data):
+                prev_items[key] = value
+            return prev_items.keys()
+
+    def values(self):
+        if self.__prev is None:
+            return self.__data.values()
+        else:
+            prev_items = dict(self.__prev.items())
+            for (key, value) in six.iteritems(self.__data):
+                prev_items[key] = value
+            return prev_items.values()
+
+    if six.PY2:
+        def iteritems(self):
+            if self.__prev is None:
+                return self.__data.iteritems()
+            else:
+                prev_items = dict(self.__prev.iteritems())
+                for (key, value) in self.__data.iteritems():
+                    prev_items[key] = value
+                return prev_items.iteritems()
+
+        def iterkeys(self):
+            if self.__prev is None:
+                return self.__data.iterkeys()
+            else:
+                prev_items = dict(self.__prev.iteritems())
+                for (key, value) in self.__data.iteritems():
+                    prev_items[key] = value
+                return prev_items.iterkeys()
+
+        def itervalues(self):
+            if self.__prev is None:
+                return self.__data.itervalues()
+            else:
+                prev_items = dict(self.__prev.iteritems())
+                for (key, value) in self.__data.iteritems():
+                    prev_items[key] = value
+                return prev_items.itervalues()
+
+    def __iter__(self):
+        return six.iterkeys(self)

--- a/tests/test_traced_data.py
+++ b/tests/test_traced_data.py
@@ -1,0 +1,151 @@
+import collections
+import time
+import unittest
+import six
+
+from core_data_modules.traced_data import TracedData
+
+
+class TestTracedData(unittest.TestCase):
+    @staticmethod
+    def td_1():
+        data = {"id": "0", "phone": "+441632000001", "gender": "man"}
+        return TracedData(data, "test_user", "run_fetcher", time.time())
+
+    @classmethod
+    def td_2(cls):
+        td = cls.td_1()
+        data_cleaned = {"gender": "male", "age": 30}
+        td.append(data_cleaned, "test_user", "demographic_cleaner", time.time())
+        return td
+
+    def test_append(self):
+        td = self.td_1()
+
+        self.assertEqual(td.get("id"), "0")
+        self.assertEqual(td.get("phone"), "+441632000001")
+        self.assertEqual(td.get("gender"), "man")
+        self.assertEqual(td.get("age"), None)
+        self.assertEqual(td.get("age", "default"), "default")
+
+        td = self.td_2()
+
+        self.assertEqual(td.get("id"), "0")
+        self.assertEqual(td.get("phone"), "+441632000001")
+        self.assertEqual(td.get("gender"), "male")
+        self.assertEqual(td.get("age"), 30)
+
+        # TODO: Test that the original data is still available.
+
+    def test___contains__(self):
+        td = self.td_1()
+
+        self.assertEqual("gender" in td, True)
+        self.assertEqual("age" in td, False)
+
+        self.assertEqual("gender" not in td, False)
+        self.assertEqual("age" not in td, True)
+
+        td = self.td_2()
+
+        self.assertEqual("gender" in td, True)
+        self.assertEqual("age" in td, True)
+
+    def test_items(self):
+        td = self.td_1()
+
+        # Test that the return type is correct for this version of Python
+        if six.PY2:
+            self.assertIs(type(td.items()), list)
+        if six.PY3:
+            self.assertIsInstance(td.items(), collections.ItemsView)
+
+        # Test that the contents of the returned data are the same
+        self.assertDictEqual(dict(td.items()),
+                             dict([("id", "0"), ("phone", "+441632000001"), ("gender", "man")]))
+
+        td = self.td_2()
+        self.assertDictEqual(dict(td.items()),
+                             dict([("id", "0"), ("phone", "+441632000001"), ("gender", "male"), ("age", 30)]))
+
+    def test_keys(self):
+        td = self.td_1()
+
+        # Test that the return type is correct for this version of Python
+        if six.PY2:
+            self.assertIs(type(td.keys()), list)
+        if six.PY3:
+            self.assertIsInstance(td.keys(), collections.KeysView)
+
+        # Test that the contents of the returned data are the same
+        self.assertSetEqual(set(td.keys()), {"id", "phone", "gender"})
+
+        td = self.td_2()
+        self.assertSetEqual(set(td.keys()), {"id", "phone", "gender", "age"})
+
+    def test_values(self):
+        td = self.td_1()
+
+        # Test that the return type is correct for this version of Python
+        if six.PY2:
+            self.assertIs(type(td.values()), list)
+        if six.PY3:
+            self.assertIsInstance(td.values(), collections.ValuesView)
+
+        # Test that the contents of the returned data are the same
+        self.assertSetEqual(set(td.values()), {"0", "+441632000001", "man"})
+
+        td = self.td_2()
+        self.assertSetEqual(set(td.values()), {"0", "+441632000001", "male", 30})
+
+    def test_iteritems(self):
+        td = self.td_1()
+
+        if six.PY3:
+            # iteritems was removed in Python 3
+            self.assertRaises(AttributeError, lambda: td.iteritems())
+            return
+
+        self.assertIsInstance(td.iteritems(), collections.Iterator)
+        self.assertDictEqual(dict(td.iteritems()),
+                             dict([("id", "0"), ("phone", "+441632000001"), ("gender", "man")]))
+
+        td = self.td_2()
+        self.assertDictEqual(dict(td.iteritems()),
+                             dict([("id", "0"), ("phone", "+441632000001"), ("gender", "male"), ("age", 30)]))
+
+    def test_iterkeys(self):
+        td = self.td_1()
+
+        if six.PY3:
+            # iterkeys was removed in Python 3
+            self.assertRaises(AttributeError, lambda: td.iterkeys())
+            return
+
+        self.assertIsInstance(td.iterkeys(), collections.Iterator)
+        self.assertSetEqual(set(td.iterkeys()), {"id", "phone", "gender"})
+
+        td = self.td_2()
+        self.assertSetEqual(set(td.iterkeys()), {"id", "phone", "gender", "age"})
+
+    def test_itervalues(self):
+        td = self.td_1()
+
+        if six.PY3:
+            # itervalues was removed in Python 3
+            self.assertRaises(AttributeError, lambda: td.itervalues())
+            return
+
+        self.assertIsInstance(td.itervalues(), collections.Iterator)
+        self.assertSetEqual(set(td.itervalues()), {"0", "+441632000001", "man"})
+
+        td = self.td_2()
+        self.assertSetEqual(set(td.itervalues()), {"0", "+441632000001", "male", 30})
+
+    def test_iter(self):
+        td = self.td_1()
+        self.assertIsInstance(iter(td), collections.Iterator)
+        self.assertSetEqual(set(iter(td)), {"id", "phone", "gender"})
+
+        td = self.td_2()
+        self.assertSetEqual(set(iter(td)), {"id", "phone", "gender", "age"})

--- a/tests/test_traced_data.py
+++ b/tests/test_traced_data.py
@@ -3,20 +3,20 @@ import time
 import unittest
 import six
 
-from core_data_modules.traced_data import TracedData
+from core_data_modules.traced_data import TracedData, Metadata
 
 
 class TestTracedData(unittest.TestCase):
     @staticmethod
     def td_1():
         data = {"id": "0", "phone": "+441632000001", "gender": "man"}
-        return TracedData(data, "test_user", "run_fetcher", time.time())
+        return TracedData(data, Metadata("test_user", "run_fetcher", time.time()))
 
     @classmethod
     def td_2(cls):
         td = cls.td_1()
         data_cleaned = {"gender": "male", "age": 30}
-        td.append(data_cleaned, "test_user", "demographic_cleaner", time.time())
+        td.append(data_cleaned, Metadata("test_user", "demographic_cleaner", time.time()))
         return td
 
     def test_append(self):


### PR DESCRIPTION
Start implementing TracedData in a way which is compatible with both Python 2 and Python 3. 

TracedData currently has the signature of a Python dict, with the following functions excluded:
d[key] = value
del d[key]
clear
fromkeys
pop
popitem
setdefault
update

Other functions still to implement are:
copy
viewitems
viewkeys
viewvalues
TracedData-specific functions.

Also still need to document.