### PR TITLE
Correct implementation of TracedData.__getitem__ to match Python dict.

### DIFF
--- a/core_data_modules/traced_data.py
+++ b/core_data_modules/traced_data.py
@@ -97,7 +97,12 @@ class TracedData(Mapping):
         return SHAUtils.sha_dict({"data": data, "prev_sha": prev_sha})
 
     def __getitem__(self, key):
-        return self.get(key)
+        if key in self._data:
+            return self._data[key]
+        elif self._prev is not None:
+            return self._prev[key]
+        else:
+            raise KeyError
 
     def get(self, key, default=None):
         if key in self._data:

--- a/tests/test_traced_data.py
+++ b/tests/test_traced_data.py
@@ -35,6 +35,7 @@ class TestTracedData(unittest.TestCase):
         self.assertEqual(td.get("gender"), "man")
         self.assertEqual(td["gender"], "man")
         self.assertEqual(td.get("age"), None)
+        self.assertRaises(KeyError, lambda: td["age"])
         self.assertEqual(td.get("age", "default"), "default")
 
         self.append_test_data(td)


### PR DESCRIPTION
It now raises a KeyError if the requested key does not exist rather than returning None as it did previously.