### PR TITLE
Interface: Export Each Demographic Line Once Only

### DIFF
--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -308,7 +308,7 @@ class TracedDataTheInterfaceIO(object):
             for td in data:
                 row = {
                     "phone": td[phone_key],
-                    "date": datetime.strftime(isoparse(td[date_key]), "%d/%m/%Y"),
+                    "date": datetime.strftime(isoparse(td[date_key]), "%m/%d/%Y"),
                     "time": datetime.strftime(isoparse(td[date_key]), "%H:%M:%S"),
                     "message": cls._clean_interface_message(td[message_key])
                 }

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -324,8 +324,13 @@ class TracedDataTheInterfaceIO(object):
 
             writer = csv.DictWriter(f, fieldnames=headers, delimiter="\t")
             writer.writeheader()
-
+            
+            exported_ids = set()
             for td in data:
+                if td[phone_key] in exported_ids:
+                    continue  # Only export demographic data for each respondent once.
+                exported_ids.add(td[phone_key])
+
                 row = {
                     "phone": td[phone_key],
                     "gender": cls._get_demographic(td, gender_key),

--- a/tests/traced_data/resources/the_interface_export_expected_inbox
+++ b/tests/traced_data/resources/the_interface_export_expected_inbox
@@ -1,4 +1,4 @@
 phone	date	time	message
-a	01/06/2018	10:47:02	message 1
-b	30/05/2018	21:00:00	message 2 is very long
-c	02/06/2018	18:30:02	message 3  has punctuation and non ascii    these need cleaning 
+a	06/01/2018	10:47:02	message 1
+b	05/30/2018	21:00:00	message 2 is very long
+c	06/02/2018	18:30:02	message 3  has punctuation and non ascii    these need cleaning 

--- a/tests/traced_data/resources/the_interface_export_expected_multiple_demo
+++ b/tests/traced_data/resources/the_interface_export_expected_multiple_demo
@@ -1,0 +1,3 @@
+phone	gender	age	county
+a	NA	NA	NA
+b	NA	NA	NA

--- a/tests/traced_data/resources/the_interface_export_expected_multiple_inbox
+++ b/tests/traced_data/resources/the_interface_export_expected_multiple_inbox
@@ -1,0 +1,4 @@
+phone	date	time	message
+a	06/01/2018	10:47:02	message message 1
+b	06/13/2018	00:00:00	message cd  e
+a	06/01/2018	10:50:00	message message 2

--- a/tests/traced_data/resources/the_interface_export_expected_tagged_inbox
+++ b/tests/traced_data/resources/the_interface_export_expected_tagged_inbox
@@ -1,3 +1,3 @@
 phone	date	time	message
-a	01/06/2018	10:47:02	key_1 abc
-b	01/06/2018	00:00:00	key_1 cd  e
+a	06/01/2018	10:47:02	key_1 abc
+b	06/13/2018	00:00:00	key_1 cd  e

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -191,7 +191,7 @@ class TestTracedDataTheInterfaceIO(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_export_traced_data_iterable_to_the_interface(self):
-        output_directory = self.test_dir
+        output_directory = "."
 
         data_dicts = [
             {"uuid": "a", "message": "Message 1", "date": "2018-06-01T10:47:02+03:00", "gender": "male",
@@ -216,11 +216,11 @@ class TestTracedDataTheInterfaceIO(unittest.TestCase):
                                     "tests/traced_data/resources/the_interface_export_expected_demo"))
 
     def test_export_traced_data_iterable_to_the_interface_with_tagging(self):
-        output_directory = "."
+        output_directory = self.test_dir
 
         data_dicts = [
             {"uuid": "a", "date": "2018-06-01T10:47:02+03:00", "key_1": "ABC"},
-            {"uuid": "b", "date": "2018-06-01T00:00:00+03:00", "key_1": u"cD: øe"}
+            {"uuid": "b", "date": "2018-06-13T00:00:00+03:00", "key_1": u"cD: øe"}
         ]
 
         data = map(

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -191,7 +191,7 @@ class TestTracedDataTheInterfaceIO(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_export_traced_data_iterable_to_the_interface(self):
-        output_directory = "."
+        output_directory = self.test_dir
 
         data_dicts = [
             {"uuid": "a", "message": "Message 1", "date": "2018-06-01T10:47:02+03:00", "gender": "male",

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -235,3 +235,25 @@ class TestTracedDataTheInterfaceIO(unittest.TestCase):
                                     "tests/traced_data/resources/the_interface_export_expected_tagged_inbox"))
         self.assertTrue(filecmp.cmp(path.join(output_directory, "demo"),
                                     "tests/traced_data/resources/the_interface_export_expected_tagged_demo"))
+
+    def test_export_traced_data_iterable_to_the_interface_multiple_sender_messages(self):
+        output_directory = "."
+
+        data_dicts = [
+            {"uuid": "a", "date": "2018-06-01T10:47:02+03:00", "message": "message 1"},
+            {"uuid": "b", "date": "2018-06-13T00:00:00+03:00", "message": u"cD: øe"},
+            {"uuid": "a", "date": "2018-06-01T10:50:00+03:00", "message": "message 2"}
+        ]
+
+        data = map(
+            lambda d: TracedData(d, Metadata("test_user", Metadata.get_call_location(), time.time())), data_dicts)
+
+        TracedDataTheInterfaceIO.export_traced_data_iterable_to_the_interface(
+            data, output_directory, "uuid",
+            message_key="message", tag_messages=True, date_key="date",
+            gender_key="gender", age_key="age", county_key="county")
+
+        self.assertTrue(filecmp.cmp(path.join(output_directory, "inbox"),
+                                    "tests/traced_data/resources/the_interface_export_expected_multiple_inbox"))
+        self.assertTrue(filecmp.cmp(path.join(output_directory, "demo"),
+                                    "tests/traced_data/resources/the_interface_export_expected_multiple_demo"))


### PR DESCRIPTION
Review #21 first.

Each respondent's demographic data is now exported only once.